### PR TITLE
Fix typo in en_us.properties

### DIFF
--- a/src/main/resources/lang/en_us.properties
+++ b/src/main/resources/lang/en_us.properties
@@ -45,7 +45,7 @@ error.patcher.no_version_manifest=Failed to download version manifest
 error.patcher.processor_fault=A processor ran into an error
 error.processor.unknown_processor=Unknown processor '%s'
 
-warn.discontinued.double_dash_minecraftVersion='--minecraftVersion' is depracticed and planned for removal in the next Major KettingLauncher Version. Please use '-minecraftVersion' instead.
+warn.discontinued.double_dash_minecraftVersion='--minecraftVersion' is deprecated and planned for removal in the next Major KettingLauncher Version. Please use '-minecraftVersion' instead.
 
 info.launcher.install_only.launch_script_success=Successfully created launch scripts, you can now launch Ketting with it
 info.launcher.install_only.success=Successfully installed Ketting, exiting install only mode


### PR DESCRIPTION
`depracticed` -> `deprecated`